### PR TITLE
Add missing dependency declaration in manifest

### DIFF
--- a/SongDataCore/SongDataCore.csproj
+++ b/SongDataCore/SongDataCore.csproj
@@ -40,7 +40,7 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
     </Reference>
     <Reference Include="Main">
-      <HintPath>D:\Games\Steam\SteamApps\common\Beat Saber\Beat Saber_Data\Managed\Main.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -50,7 +50,7 @@
       <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>
     </Reference>
     <Reference Include="SongCore">
-      <HintPath>D:\Games\Steam\SteamApps\common\Beat Saber\Plugins\SongCore.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Plugins\SongCore.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>

--- a/SongDataCore/manifest.json
+++ b/SongDataCore/manifest.json
@@ -8,6 +8,7 @@
   "version": "1.4.4",
   "dependsOn": {
     "BSIPA": "^4.1.3",
+    "BS Utils": "^1.9.0",
     "SongCore": "^3.7.0"
   },
   "misc": {


### PR DESCRIPTION
SDC uses BSEvents in Plugin.cs, thus it is dependent on BS Utils being present.

Also updated two references in the project file to make use of the already used BeatSaberDir variable.